### PR TITLE
Support for record access with an atom key.

### DIFF
--- a/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
+++ b/erlang-squid/src/main/java/org/sonar/erlang/parser/ErlangGrammarImpl.java
@@ -545,7 +545,7 @@ public enum ErlangGrammarImpl implements GrammarRuleKey {
       b.zeroOrMore(
         b.firstOf(
           // in defines a record might have an identifier to access a field
-          b.sequence(numbersign, primaryExpression, b.optional(".", identifier)),
+          b.sequence(numbersign, primaryExpression, b.optional(".", atomOrIdentifier)),
           b.sequence(macroLiteral, b.optional(".", primaryExpression)))
       )
       ).skipIfOneChild();

--- a/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangRealCodeTest.java
+++ b/erlang-squid/src/test/java/org/sonar/erlang/parser/ErlangRealCodeTest.java
@@ -60,6 +60,11 @@ public class ErlangRealCodeTest {
     assertThat(b.getRootRule()).matches((readFromFile("megaco.erl")));
   }
 
+  @Test
+  public void parseAdvancedMacroAccess() throws IOException, URISyntaxException {
+    assertThat(b.getRootRule()).matches((readFromFile("macro_test.erl")));
+  }
+
   private String readFromFile(String fileName) throws IOException, URISyntaxException {
     StringBuilder text = new StringBuilder();
     File file = new File(ErlangRealCodeTest.class.getClassLoader().getResource(fileName)

--- a/erlang-squid/src/test/resources/macro_test.erl
+++ b/erlang-squid/src/test/resources/macro_test.erl
@@ -1,0 +1,6 @@
+-module(my_type).
+
+-spec my_field(my_type:my_type()) -> atom() | tuple().
+
+my_field(MyType) ->
+    (my_type:my_type(MyType))#?MY_TYPE.my_field.


### PR DESCRIPTION
The following syntax doesn't appear to be supported:

```erlang
Value#?MY_RECORD.my_field.
```

A simple parser change fixes this issue.