### PR TITLE
SonarQube Community 26.2 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          # SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn clean -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -X

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
           java-version: 17
           distribution: 'oracle'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4.0.0
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,28 +10,17 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
+          fetch-depth: 0
+
+      - name: Set up JDK
         uses: actions/setup-java@v4.0.0
         with:
           java-version: 17
-          distribution: 'oracle'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: Build and analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          # SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn clean -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -X
+          distribution: corretto
+          cache: maven
+
+      - name: Build
+        run: mvn clean package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
           java-version: 17
           distribution: 'oracle'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v4.0.0
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v4.0.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ target/
 
 # SonarQube
 .sonar/
-sonar/data/es7/
+sonar/logs/
+sonar/data/es*/
 sonar/data/logs/
 sonar/data/sonar.mv.db
 sonar/data/web/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A sample project is available on GitHub: https://github.com/SonarSource/sonar-sc
 
 Maven and Ant can also be used to launch analysis on Erlang projects.
 
-The plugin has been tested to work with SonarQube Community Version `9.9.1` .
+The plugin has been tested to work with SonarQube Community Version `26.2`.
 
 ### Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   sq:
-    image: 'sonarqube:9.9.1-community'
+    image: 'sonarqube:26.2.0.119303-community'
     ports:
       - '9000:9000'
     volumes:

--- a/erlang-checks/pom.xml
+++ b/erlang-checks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.evolution.sonarqube.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </parent>
 
   <artifactId>erlang-checks</artifactId>

--- a/erlang-checks/pom.xml
+++ b/erlang-checks/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.evolution.sonarqube.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.7</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>erlang-checks</artifactId>

--- a/erlang-squid/pom.xml
+++ b/erlang-squid/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.evolution.sonarqube.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </parent>
 
   <artifactId>erlang-squid</artifactId>

--- a/erlang-squid/pom.xml
+++ b/erlang-squid/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.evolution.sonarqube.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.7</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>erlang-squid</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,10 +73,6 @@
         <sonar.api.plugin.version>9.14.0.375</sonar.api.plugin.version>
         <sslr.version>1.24.0.633</sslr.version>
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
-        <sonar.projectKey>evolution-gaming_sonar-erlang</sonar.projectKey>
-        <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
-        <sonar.organization>evolution-gaming</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	<sonar.coverage.jacoco.xmlReportPaths>${_rootdir}/sonar-erlang-plugin/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.evolution.sonarqube.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
     <packaging>pom</packaging>
 
     <name>Erlang</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.evolution.sonarqube.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.7</version>
+    <version>1.6.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Erlang</name>

--- a/sonar-erlang-plugin/pom.xml
+++ b/sonar-erlang-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.evolution.sonarqube.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </parent>
 
   <artifactId>sonar-erlang-plugin</artifactId>

--- a/sonar-erlang-plugin/pom.xml
+++ b/sonar-erlang-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.evolution.sonarqube.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.7</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-erlang-plugin</artifactId>

--- a/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangPlugin.java
+++ b/sonar-erlang-plugin/src/main/java/org/sonar/plugins/erlang/ErlangPlugin.java
@@ -106,8 +106,8 @@ public class ErlangPlugin implements Plugin {
   @Override
   public void define(Context context) {
     // languages
-    context.addExtension(ErlangLanguage.class);
-    context.addExtension(ErlangLanguageProperties.getProperties());
+    context.addExtensions(ErlangLanguage.class, ErlangQualityProfile.class);
+    context.addExtensions(ErlangLanguageProperties.getProperties());
 
     context.addExtensions(
         ErlangHighlighter.class,
@@ -119,7 +119,6 @@ public class ErlangPlugin implements Plugin {
         DialyzerRuleDefinition.class,
         ElvisRuleDefinition.class,
         XrefRuleDefinition.class,
-        ErlangQualityProfile.class,
 
         EunitXmlSensor.class,
 

--- a/sslr-erlang-toolkit/pom.xml
+++ b/sslr-erlang-toolkit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.evolution.sonarqube.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.7</version>
+    <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>sslr-erlang-toolkit</artifactId>

--- a/sslr-erlang-toolkit/pom.xml
+++ b/sslr-erlang-toolkit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.evolution.sonarqube.erlang</groupId>
     <artifactId>erlang</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </parent>
 
   <artifactId>sslr-erlang-toolkit</artifactId>


### PR DESCRIPTION
This PR adds support for the newer SQ versions by rearranging the way the extensions are added in the plugin.